### PR TITLE
docs: fold Features into intro prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,7 @@
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D22-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?logo=opensourceinitiative&logoColor=white)](https://opensource.org/licenses/MIT)
 
-Download audiobooks from Libby to your computer for offline listening.
-
-## Features
-
-- **One-Click Downloads**: Chrome extension downloads audiobooks directly from Libby
-- **MP3 Tagging**: CLI adds title, author, narrator, and cover art to downloaded files
-- **M4B Audiobooks**: Merge chapters into a single audiobook file with chapter markers
+A Chrome extension and CLI for downloading audiobooks from Libby for offline listening. The extension grabs files directly from Libby; the CLI tags MP3s with title, author, narrator, and cover art, or merges chapters into a single M4B audiobook with chapter markers.
 
 ## Setup
 


### PR DESCRIPTION
Folds the existing `## Features` bullet list into the opening prose paragraph for consistency with the rest of the fleet's README style. No content removed — every capability the bullets called out is still mentioned, just in flowing prose. Style matches `rewind`, `e-ink-scoreboard`, `chat-app-prototype`, `claudelint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)