### PR TITLE
ci: drop the needless self-approve step from dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,13 +17,6 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Approve PR
-        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Enable auto-merge
         if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Removes the `gh pr review --approve` step from the Dependabot auto-merge workflow.

**It grants nothing.** This repo requires **0** approving reviews (verified across all 30 repos — none require any), so the approval satisfies no rule.

**And it actively breaks auto-merge.** When a repo's *Allow GitHub Actions to create and approve pull requests* setting is off, the step fails with:

```
failed to create review: GraphQL: GitHub Actions is not permitted to approve pull requests.
```

The job runs under `bash -e`, so that aborts it **before** `gh pr merge --auto` — auto-merge is never armed and every Dependabot PR waits on a human. Three repos were stalled this way, one with 23 PRs backed up.

Dropping the step lets auto-merge work regardless of that setting, which in turn lets the setting be turned back **off** — a workflow that can self-approve would defeat review requirements if any are ever added.

`gh pr merge --auto` and all conditional logic are unchanged.

Found by a cross-repo audit on 2026-07-21.