### PR TITLE
fix: refresh metadata reprocessing support

### DIFF
--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 FIXTURES_DIR="$PROJECT_DIR/fixtures"
+EXPECTED_VERSION=$(node -p "require('$PROJECT_DIR/package.json').version")
 
 cli() {
   FORCE_COLOR=0 npx tsx "$PROJECT_DIR/src/cli.ts" "$@" 2>&1 | sed $'s/\x1b\[[0-9;?]*[a-zA-Z]//g; s/\x1b\[J//g'
@@ -210,10 +211,23 @@ assert_output_contains "shows already exists error" "$OUTPUT" "already exists"
 echo ""
 
 # ──────────────────────────────────────────────────────────────
-# Test 9: help output
+# Test 9: force re-merge
 # ──────────────────────────────────────────────────────────────
 
-echo -e "${BOLD}9. help output${RESET}"
+echo -e "${BOLD}9. force re-merge${RESET}"
+OUTPUT=$(cli merge "$FIXTURES_DIR/The Great Adventure" --force) || true
+EXIT_CODE=$?
+
+assert_exit_code "force re-merge exits successfully" "$EXIT_CODE" "0"
+assert_output_contains "force re-merge shows output file" "$OUTPUT" "The Great Adventure.m4b"
+assert_file_exists "force re-merge replaces m4b file" "$FIXTURES_DIR/The Great Adventure/The Great Adventure.m4b"
+echo ""
+
+# ──────────────────────────────────────────────────────────────
+# Test 10: help output
+# ──────────────────────────────────────────────────────────────
+
+echo -e "${BOLD}10. help output${RESET}"
 OUTPUT=$(cli --help)
 
 assert_output_contains "shows program name" "$OUTPUT" "libby"
@@ -225,23 +239,23 @@ assert_output_contains "shows verbose option" "$OUTPUT" "--verbose"
 echo ""
 
 # ──────────────────────────────────────────────────────────────
-# Test 10: verbose mode
+# Test 11: verbose mode
 # ──────────────────────────────────────────────────────────────
 
-echo -e "${BOLD}10. verbose mode${RESET}"
+echo -e "${BOLD}11. verbose mode${RESET}"
 OUTPUT=$(cli list --data-dir "$FIXTURES_DIR" --verbose)
 
 assert_output_contains "shows verbose output" "$OUTPUT" "Libby Downloader"
 echo ""
 
 # ──────────────────────────────────────────────────────────────
-# Test 11: version flag
+# Test 12: version flag
 # ──────────────────────────────────────────────────────────────
 
-echo -e "${BOLD}11. version flag${RESET}"
+echo -e "${BOLD}12. version flag${RESET}"
 OUTPUT=$(cli --version)
 
-assert_output_contains "shows version" "$OUTPUT" "1.0.0"
+assert_output_contains "shows version" "$OUTPUT" "$EXPECTED_VERSION"
 echo ""
 
 # ──────────────────────────────────────────────────────────────

--- a/src/__tests__/commands/interactive.test.ts
+++ b/src/__tests__/commands/interactive.test.ts
@@ -1,10 +1,20 @@
-/**
- * Tests for interactive command (placeholder)
- * The Ink-based InteractiveMenu component is tested via CLI integration tests.
- */
+import { createMergedBook, createTaggedBook } from '../setup/fixtures/books.fixture';
+import { getMergeSelectionBooks, getTagSelectionBooks } from '../../ui/ink/InteractiveMenu';
 
 describe('Interactive menu', () => {
-  it('should be tested via CLI integration tests', () => {
-    expect(true).toBe(true);
+  it('should allow selecting an already-tagged book for re-tagging', () => {
+    const taggedBook = createTaggedBook();
+
+    const selectableBooks = getTagSelectionBooks([taggedBook]);
+
+    expect(selectableBooks).toEqual([taggedBook]);
+  });
+
+  it('should allow selecting an already-merged book for re-merging', () => {
+    const mergedBook = createMergedBook();
+
+    const selectableBooks = getMergeSelectionBooks([mergedBook]);
+
+    expect(selectableBooks).toEqual([mergedBook]);
   });
 });

--- a/src/__tests__/commands/merge.test.ts
+++ b/src/__tests__/commands/merge.test.ts
@@ -31,4 +31,16 @@ describe('mergeBook command', () => {
 
     await expect(mergeBook('/test/book')).rejects.toThrow('Failed to merge');
   });
+
+  it('should pass force through to MergeService', async () => {
+    mockMergeService.mergeFolder.mockResolvedValue({
+      outputPath: '/test/book/Book.m4b',
+      outputFilename: 'Book.m4b',
+      fileSize: 1024,
+    });
+
+    await mergeBook('/test/book', { force: true });
+
+    expect(mockMergeService.mergeFolder).toHaveBeenCalledWith('/test/book', { force: true });
+  });
 });

--- a/src/__tests__/services/merge-service.test.ts
+++ b/src/__tests__/services/merge-service.test.ts
@@ -159,6 +159,15 @@ describe('MergeService', () => {
       await expect(mergeService.mergeFolder('/test/book')).rejects.toThrow('already exists');
     });
 
+    it('should replace an existing output file when force is enabled', async () => {
+      mockFs.access.mockResolvedValue(undefined);
+
+      const result = await mergeService.mergeFolder('/test/book', { force: true });
+
+      expect(mockFs.unlink).toHaveBeenCalledWith('/test/book/Sample Audiobook.m4b');
+      expect(result.outputPath).toBe('/test/book/Sample Audiobook.m4b');
+    });
+
     it('should handle cover art download failure gracefully', async () => {
       mockFetch.mockRejectedValue(new Error('Network error'));
 
@@ -239,6 +248,32 @@ describe('MergeService', () => {
       const result = await mergeService.mergeFolder('/test/book');
 
       expect(result.outputPath).toContain('.m4b');
+    });
+
+    it('should write plural narrators to M4B metadata', async () => {
+      mockFs.readFile.mockImplementation((path: any) => {
+        if (path.includes('metadata.json')) {
+          const metadata = createMockMetadata();
+          delete metadata.metadata.narrator;
+          return Promise.resolve(
+            JSON.stringify({
+              ...metadata,
+              metadata: {
+                ...metadata.metadata,
+                narrators: ['Narrator One', 'Narrator Two'],
+              },
+            })
+          );
+        }
+        return Promise.reject(new Error('File not found'));
+      });
+
+      await mergeService.mergeFolder('/test/book');
+
+      const metadataWrite = mockFs.writeFile.mock.calls.find((call) =>
+        call[0].toString().includes('metadata.txt')
+      );
+      expect(metadataWrite?.[1]).toContain('album_artist=Narrator One, Narrator Two');
     });
   });
 });

--- a/src/__tests__/services/metadata-service.test.ts
+++ b/src/__tests__/services/metadata-service.test.ts
@@ -173,6 +173,57 @@ describe('MetadataService', () => {
         expect.any(String)
       );
     });
+
+    it('should use plural narrators from extension metadata', async () => {
+      const metadataWithNarrators = {
+        metadata: {
+          title: 'Test Book',
+          authors: ['Author'],
+          narrators: ['Narrator One', 'Narrator Two'],
+        },
+        chapters: [{ index: 0, title: 'Chapter 1', duration: 100 }],
+      };
+
+      mockFs.readFile.mockImplementation((path: any) => {
+        if (path.includes('metadata.json')) {
+          return Promise.resolve(JSON.stringify(metadataWithNarrators));
+        }
+        return Promise.reject(new Error('File not found'));
+      });
+      mockFs.readdir.mockResolvedValue(['chapter-1.mp3', 'metadata.json'] as any);
+
+      await metadataService.embedToFolder('/test/book');
+
+      expect(mockNodeID3.write).toHaveBeenCalledWith(
+        expect.objectContaining({
+          performerInfo: 'Narrator One, Narrator Two',
+        }),
+        '/test/book/chapter-1.mp3'
+      );
+    });
+
+    it('should apply CLI overrides on top of metadata.json values', async () => {
+      await metadataService.embedToFolder('/test/book', {
+        title: 'Override Title',
+        author: 'Override Author',
+        narrator: 'Override Narrator',
+        coverUrl: 'https://example.com/override.jpg',
+        description: 'Override description',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith('https://example.com/override.jpg');
+      expect(mockNodeID3.write).toHaveBeenCalledWith(
+        expect.objectContaining({
+          album: 'Override Title',
+          artist: 'Override Author',
+          performerInfo: 'Override Narrator',
+          comment: expect.objectContaining({
+            text: 'Override description',
+          }),
+        }),
+        expect.any(String)
+      );
+    });
   });
 
   describe('embedToFile', () => {

--- a/src/__tests__/ui/book-presenter.test.ts
+++ b/src/__tests__/ui/book-presenter.test.ts
@@ -78,6 +78,21 @@ describe('BookPresenter', () => {
 
       expect(presenter.getNarrator(book)).toBeUndefined();
     });
+
+    it('should join plural narrators from extension metadata', () => {
+      const book = createMockBookInfo({
+        metadataJson: {
+          metadata: {
+            title: 'Title',
+            authors: ['Author'],
+            narrators: ['Narrator One', 'Narrator Two'],
+          },
+          chapters: [],
+        },
+      });
+
+      expect(presenter.getNarrator(book)).toBe('Narrator One, Narrator Two');
+    });
   });
 
   describe('getCoverUrl', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -81,7 +81,8 @@ program
 program
   .command('merge [folder]')
   .description('Merge MP3 chapters into single M4B audiobook (interactive if no folder specified)')
-  .action(async (folder, _options, cmd: Command) => {
+  .option('--force', 'Overwrite an existing M4B file')
+  .action(async (folder, options, cmd: Command) => {
     if (!folder) {
       const instance = render(
         createElement(App, { command: 'interactive', dataDir: getDataDir(cmd) })
@@ -90,7 +91,13 @@ program
       return;
     }
 
-    const instance = render(createElement(App, { command: 'merge', folder }));
+    const instance = render(
+      createElement(App, {
+        command: 'merge',
+        folder,
+        mergeOptions: { force: options.force },
+      })
+    );
     await instance.waitUntilExit();
   });
 

--- a/src/commands/merge.ts
+++ b/src/commands/merge.ts
@@ -5,10 +5,18 @@
 
 import { MergeService } from '../services/merge-service';
 
+export interface MergeOptions {
+  force?: boolean;
+}
+
 /**
  * Merge MP3 chapters in a folder into a single M4B audiobook (non-interactive, no UI)
  */
-export async function mergeBook(folderPath: string): Promise<void> {
+export async function mergeBook(folderPath: string, options: MergeOptions = {}): Promise<void> {
   const mergeService = new MergeService();
+  if (options.force) {
+    await mergeService.mergeFolder(folderPath, { force: true });
+    return;
+  }
   await mergeService.mergeFolder(folderPath);
 }

--- a/src/services/merge-service.ts
+++ b/src/services/merge-service.ts
@@ -17,6 +17,7 @@ interface BookMetadata {
     title: string;
     authors: string[];
     narrator?: string;
+    narrators?: string[];
     coverUrl?: string;
     description?: string | { full: string; short: string };
   };
@@ -43,19 +44,20 @@ export interface MergeResult {
   fileSize: number;
 }
 
-export interface MergeProgressCallback {
+export interface MergeOptions {
   onStageChange?: (stage: string) => void;
   onMergeStart?: (totalDurationSecs: number, chapterCount: number) => void;
   onMergeProgress?: (timemark: string) => void;
   onComplete?: (filename: string, fileSize: number) => void;
   signal?: AbortSignal;
+  force?: boolean;
 }
 
 export class MergeService {
   /**
    * Merge all chapter MP3 files in a folder into a single M4B audiobook
    */
-  async mergeFolder(folderPath: string, onProgress?: MergeProgressCallback): Promise<MergeResult> {
+  async mergeFolder(folderPath: string, options?: MergeOptions): Promise<MergeResult> {
     const resolved = path.resolve(folderPath);
 
     // Validate folder
@@ -65,15 +67,15 @@ export class MergeService {
     }
 
     // Load metadata
-    onProgress?.onStageChange?.('Loading metadata...');
+    options?.onStageChange?.('Loading metadata...');
     const metadata = await this.loadMetadata(resolved);
 
     // Find chapter files
-    onProgress?.onStageChange?.('Finding chapters...');
+    options?.onStageChange?.('Finding chapters...');
     const chapterFiles = await this.findChapterFiles(resolved);
 
     // Calculate chapter timestamps
-    onProgress?.onStageChange?.('Calculating timestamps...');
+    options?.onStageChange?.('Calculating timestamps...');
     const chapters = await this.calculateChapterInfo(resolved, chapterFiles, metadata);
 
     // Create temp directory
@@ -81,7 +83,7 @@ export class MergeService {
 
     try {
       // Generate merge files
-      onProgress?.onStageChange?.('Preparing merge files...');
+      options?.onStageChange?.('Preparing merge files...');
 
       const concatFilePath = path.join(tmpDir, 'concat.txt');
       await this.createConcatFile(chapterFiles, resolved, concatFilePath);
@@ -104,7 +106,13 @@ export class MergeService {
 
       try {
         await fs.access(outputPath);
-        throw new Error(`Output file already exists: ${outputFilename}`);
+        if (options?.force) {
+          await fs.unlink(outputPath);
+        } else {
+          throw new Error(
+            `Output file already exists: ${outputFilename} (use --force to overwrite)`
+          );
+        }
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
           throw error;
@@ -113,22 +121,22 @@ export class MergeService {
 
       // Execute merge
       const totalDurationSecs = chapters.reduce((sum, ch) => sum + ch.duration, 0);
-      onProgress?.onStageChange?.(`Merging ${chapterFiles.length} chapters...`);
-      onProgress?.onMergeStart?.(totalDurationSecs, chapterFiles.length);
+      options?.onStageChange?.(`Merging ${chapterFiles.length} chapters...`);
+      options?.onMergeStart?.(totalDurationSecs, chapterFiles.length);
       await this.executeMerge(
         concatFilePath,
         metadataFilePath,
         coverArtPath,
         outputPath,
         (timemark) => {
-          onProgress?.onMergeProgress?.(timemark);
+          options?.onMergeProgress?.(timemark);
         },
-        onProgress?.signal
+        options?.signal
       );
 
       // Get result info
       const fileSize = (await fs.stat(outputPath)).size;
-      onProgress?.onComplete?.(outputFilename, fileSize);
+      options?.onComplete?.(outputFilename, fileSize);
 
       return { outputPath, outputFilename, fileSize };
     } finally {
@@ -289,8 +297,10 @@ export class MergeService {
     lines.push(`album=${metadata.metadata.title}`);
     lines.push('genre=Audiobook');
 
-    if (metadata.metadata.narrator) {
-      lines.push(`album_artist=${metadata.metadata.narrator}`);
+    const narrator =
+      metadata.metadata.narrators?.filter(Boolean).join(', ') || metadata.metadata.narrator;
+    if (narrator) {
+      lines.push(`album_artist=${narrator}`);
     }
 
     const description =

--- a/src/services/metadata-service.ts
+++ b/src/services/metadata-service.ts
@@ -26,6 +26,7 @@ interface BookMetadata {
     subtitle?: string;
     authors: string[];
     narrator?: string;
+    narrators?: string[];
     coverUrl?: string;
     description?: string | { full: string; short: string };
   };
@@ -197,12 +198,16 @@ export class MetadataService {
           bookMetadata.metadata.description.short || bookMetadata.metadata.description.full || '';
       }
 
+      const narrator =
+        bookMetadata.metadata.narrators?.filter(Boolean).join(', ') ||
+        bookMetadata.metadata.narrator;
+
       return {
-        title: bookMetadata.metadata.title,
-        authors: bookMetadata.metadata.authors,
-        narrator: bookMetadata.metadata.narrator,
-        coverUrl: bookMetadata.metadata.coverUrl,
-        description,
+        title: options.title ?? bookMetadata.metadata.title,
+        authors: options.author ? [options.author] : bookMetadata.metadata.authors,
+        narrator: options.narrator ?? narrator,
+        coverUrl: options.coverUrl ?? bookMetadata.metadata.coverUrl,
+        description: options.description ?? description,
         chapters: bookMetadata.chapters,
       };
     }

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -14,6 +14,7 @@ export interface BookInfo {
       title: string;
       authors: string[];
       narrator?: string;
+      narrators?: string[];
       coverUrl?: string;
     };
     chapters: Array<{ title: string }>;

--- a/src/ui/ink/App.tsx
+++ b/src/ui/ink/App.tsx
@@ -11,9 +11,12 @@ export interface AppProps {
   dataDir?: string;
   folder?: string;
   tagOptions?: EmbedOptions;
+  mergeOptions?: {
+    force?: boolean;
+  };
 }
 
-export function App({ command, dataDir, folder, tagOptions }: AppProps) {
+export function App({ command, dataDir, folder, tagOptions, mergeOptions }: AppProps) {
   const { exit } = useApp();
 
   if (command === 'interactive') {
@@ -42,7 +45,12 @@ export function App({ command, dataDir, folder, tagOptions }: AppProps) {
     return (
       <Box flexDirection="column" marginY={1}>
         <Header />
-        <MergeProgress folderPath={folder} onComplete={() => exit()} onError={() => exit()} />
+        <MergeProgress
+          folderPath={folder}
+          force={mergeOptions?.force}
+          onComplete={() => exit()}
+          onError={() => exit()}
+        />
       </Box>
     );
   }

--- a/src/ui/ink/BookSelect.tsx
+++ b/src/ui/ink/BookSelect.tsx
@@ -45,8 +45,13 @@ export function BookSelect({
 
     let label = bookPresenter.getDisplayName(book);
     if (showStatus) {
-      const status = book.isTagged ? ' [tagged]' : '';
-      label += status;
+      const statuses = [
+        book.isTagged ? 'tagged' : undefined,
+        book.isMerged ? 'merged' : undefined,
+      ].filter(Boolean);
+      if (statuses.length > 0) {
+        label += ` [${statuses.join(', ')}]`;
+      }
     }
 
     items.push({ label, value: key });

--- a/src/ui/ink/InteractiveMenu.tsx
+++ b/src/ui/ink/InteractiveMenu.tsx
@@ -26,6 +26,14 @@ const menuItems = [
   { label: 'Exit', value: 'exit' },
 ];
 
+export function getTagSelectionBooks(books: BookInfo[]): BookInfo[] {
+  return books;
+}
+
+export function getMergeSelectionBooks(books: BookInfo[]): BookInfo[] {
+  return books;
+}
+
 export function InteractiveMenu({ dataDir }: MenuProps) {
   const { exit } = useApp();
   const bookPresenter = new BookPresenter();
@@ -57,20 +65,10 @@ export function InteractiveMenu({ dataDir }: MenuProps) {
     setMessage('');
     switch (item.value) {
       case 'tag': {
-        const untagged = books.filter((b) => !b.isTagged);
-        if (untagged.length === 0) {
-          setMessage('All books are already tagged.');
-          return;
-        }
         setView('tag-select');
         break;
       }
       case 'merge': {
-        const unmerged = books.filter((b) => !b.isMerged);
-        if (unmerged.length === 0) {
-          setMessage('All books are already merged.');
-          return;
-        }
         setView('merge-select');
         break;
       }
@@ -92,9 +90,14 @@ export function InteractiveMenu({ dataDir }: MenuProps) {
       return;
     }
     if (Array.isArray(result)) {
-      setTagBatch(result);
+      const untagged = result.filter((book) => !book.isTagged);
+      if (untagged.length === 0) {
+        setView('menu');
+        return;
+      }
+      setTagBatch(untagged);
       setTagBatchIndex(0);
-      setSelectedBook(result[0]);
+      setSelectedBook(untagged[0]);
       setView('tagging');
     } else {
       setTagBatch([]);
@@ -172,11 +175,11 @@ export function InteractiveMenu({ dataDir }: MenuProps) {
       <Box flexDirection="column" marginY={1}>
         <Header total={stats.total} tagged={stats.tagged} merged={stats.merged} />
         <BookSelect
-          books={books}
+          books={getTagSelectionBooks(books)}
           message="Which book do you want to tag?"
-          filter={(b) => !b.isTagged}
-          allowAll
+          allowAll={stats.untagged > 0}
           allButtonText={`Tag all ${stats.untagged} untagged books`}
+          showStatus
           onSelect={handleTagSelect}
         />
       </Box>
@@ -202,7 +205,7 @@ export function InteractiveMenu({ dataDir }: MenuProps) {
   }
 
   if (view === 'merge-select') {
-    const untaggedCount = books.filter((b) => !b.isMerged && !b.isTagged).length;
+    const untaggedCount = books.filter((b) => !b.isTagged).length;
     return (
       <Box flexDirection="column" marginY={1}>
         <Header total={stats.total} tagged={stats.tagged} merged={stats.merged} />
@@ -214,9 +217,8 @@ export function InteractiveMenu({ dataDir }: MenuProps) {
           </Box>
         )}
         <BookSelect
-          books={books}
+          books={getMergeSelectionBooks(books)}
           message="Which book do you want to merge?"
-          filter={(b) => !b.isMerged}
           showStatus
           onSelect={handleMergeSelect}
         />
@@ -236,6 +238,7 @@ export function InteractiveMenu({ dataDir }: MenuProps) {
         </Box>
         <MergeProgress
           folderPath={selectedBook.path}
+          force={selectedBook.isMerged}
           onComplete={handleMergeComplete}
           onError={() => refreshBooks().then(() => setView('menu'))}
         />

--- a/src/ui/ink/MergeProgress.tsx
+++ b/src/ui/ink/MergeProgress.tsx
@@ -6,6 +6,7 @@ import { ProgressBar } from './ProgressBar';
 
 interface MergeProgressProps {
   folderPath: string;
+  force?: boolean;
   onComplete: () => void;
   onError?: (error: Error) => void;
 }
@@ -51,7 +52,12 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
-export function MergeProgress({ folderPath, onComplete, onError }: MergeProgressProps) {
+export function MergeProgress({
+  folderPath,
+  force = false,
+  onComplete,
+  onError,
+}: MergeProgressProps) {
   const [state, setState] = useState<MergeState>({
     stage: 'Preparing...',
     timemark: '',
@@ -63,12 +69,15 @@ export function MergeProgress({ folderPath, onComplete, onError }: MergeProgress
   const startTimeRef = useRef<number>(0);
   const abortRef = useRef<AbortController | null>(null);
 
-  useInput((_input, key) => {
-    if (key.escape && !state.done && !state.cancelled) {
-      abortRef.current?.abort();
-      setState((prev) => ({ ...prev, cancelled: true, done: true }));
-    }
-  });
+  useInput(
+    (_input, key) => {
+      if (key.escape && !state.done && !state.cancelled) {
+        abortRef.current?.abort();
+        setState((prev) => ({ ...prev, cancelled: true, done: true }));
+      }
+    },
+    { isActive: Boolean(process.stdin.isTTY) }
+  );
 
   useEffect(() => {
     const controller = new AbortController();
@@ -76,6 +85,7 @@ export function MergeProgress({ folderPath, onComplete, onError }: MergeProgress
     const service = new MergeService();
     service
       .mergeFolder(folderPath, {
+        force,
         onStageChange: (stage) => {
           setState((prev) => ({ ...prev, stage }));
         },

--- a/src/ui/presenters/book-presenter.ts
+++ b/src/ui/presenters/book-presenter.ts
@@ -23,7 +23,8 @@ export class BookPresenter {
    * Get the narrator of a book
    */
   getNarrator(book: BookInfo): string | undefined {
-    return book.metadataJson?.metadata.narrator;
+    const metadata = book.metadataJson?.metadata;
+    return metadata?.narrators?.filter(Boolean).join(', ') || metadata?.narrator;
   }
 
   /**


### PR DESCRIPTION
## Summary

- read the extension narrator schema (narrators array) while retaining legacy singular narrator compatibility
- let direct CLI metadata overrides take precedence over metadata.json
- allow re-tagging and re-merging completed books from the current Ink interface
- add an explicit merge --force path and keep non-TTY merge automation usable
- refresh the CLI integration harness and cover forced re-merge behavior

## Why

This is the current-main port of the valid behavior from #21. The original branch predates the Ink UI migration and can no longer be merged as-is.

## Validation

- 189 Jest tests pass with coverage
- typecheck, ESLint, and Prettier checks pass
- CLI integration suite: 35/35 pass, including real force re-merge
- production CLI and extension build succeeds
- pre-push extension validation reports only existing Firefox-specific notices

Supersedes #21.