### PR TITLE
chore: standardize automated code and dependency review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,15 @@
 # Libby Downloader - Development Guide
 
-## Work modes
-
-- Default to exploration for design iterations, prototypes, and small changes. Make focused edits directly; do not require a formal spec, separate plan, worktree, or TDD.
-- Apply production rigor when the user explicitly asks to ship, harden, prepare a release, or use strict TDD. Match verification to risk and obey any stronger test requirements below.
-- Ask before deployments, production-data changes, live service mutations, schema migrations, or security-rule changes.
-
 TypeScript CLI tool for managing audiobooks downloaded from Libby via Chrome extension.
+
+## Code Review Rules
+
+- Flag any production path that logs, persists beyond the required download flow, or
+  exposes Libby session material, playback keys, signed chapter URLs, or raw account data.
+- Flag file operations that accept unvalidated paths, overwrite unrelated files, escape
+  the selected book/output directory, or leave partial destructive results after failure.
+- Flag Chrome content-script builds that introduce runtime ES-module imports, or service
+  code that imports the Ink UI instead of reporting progress through callbacks.
 
 ## Common Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,1 @@
-# Shared agent guidance
-
 @AGENTS.md

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,21 @@
+# Libby Downloader threat model
+
+## Protected assets and boundaries
+
+Protected assets are Libby session and playback material, signed chapter URLs, audiobook
+files and metadata, browser permissions, and the user's filesystem. Page scripts, BIF
+objects, downloaded media, metadata files, CLI paths, and FFmpeg input are untrusted.
+
+## Required controls
+
+- Retain session and playback material only as long as the authorized download requires;
+  never log it or copy it into fixtures, telemetry, errors, or release artifacts.
+- Validate and resolve every input/output path beneath the selected book or output root;
+  do not overwrite unrelated files or follow unsafe symlinks.
+- Use temporary output plus atomic replacement for tagging and merges, and clean partial
+  results without deleting original chapters on failure.
+- Keep extension permissions minimal and preserve the isolated-world/main-world boundary.
+- Test external and browser behavior with mocks and synthetic fixtures, not a real account.
+
+Update this model when permissions, page extraction, key handling, downloads, filesystem
+operations, FFmpeg invocation, or telemetry changes.


### PR DESCRIPTION
## What changed

- Makes `AGENTS.md` the canonical cross-agent instruction source while preserving Claude compatibility where applicable.
- Adds repository-specific code-review guidance and a checked-in threat model where the repository risk profile warrants one.
- Adds or repairs Dependabot and deterministic CI coverage where needed.

## Why

This standardizes code review, dependency maintenance, and merge governance across the portfolio without API-key billing, OpenAI auto-top-ups, paid plan upgrades, or automatic dependency merges.

## Validation

- Portfolio-wide `actionlint`: 153 workflows passed.
- Policy, Dependabot schema, and manifest-path validation passed.
- Repository pre-push checks passed before this isolated rollout branch was published.

## Rollout notes

This is intentionally a draft so its checks and diff can be reviewed before merge. Native Codex code/security review will be enabled separately through the included-usage settings.