### PR TITLE
docs: standardize README title and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Libby Downloader
+# libby-downloader
 
-[![CI](https://github.com/pdugan20/libby-downloader/workflows/CI/badge.svg)](https://github.com/pdugan20/libby-downloader/actions)
-[![Release](https://img.shields.io/github/v/release/pdugan20/libby-downloader?logo=github)](https://github.com/pdugan20/libby-downloader/releases)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow?logo=opensourceinitiative&logoColor=white)](https://opensource.org/licenses/MIT)
+[![CI](https://github.com/pdugan20/libby-downloader/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/pdugan20/libby-downloader/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/pdugan20/libby-downloader)](https://github.com/pdugan20/libby-downloader/releases/latest)
+[![License](https://img.shields.io/github/license/pdugan20/libby-downloader)](LICENSE)
 
 A Chrome extension and CLI for downloading audiobooks from Libby for offline listening. The extension grabs files directly from Libby; the CLI tags MP3s with title, author, narrator, and cover art, or merges chapters into a single M4B audiobook with chapter markers.
 


### PR DESCRIPTION
## Summary

- normalize the README H1 to the exact lowercase repository slug
- standardize the top badge block around provider-default, authoritative project signals
- leave all README body copy unchanged

## Why

This applies the approved fleet convention based on `readwise-reader-import` and the external repository sample. Decorative implementation badges are omitted; package compatibility, documentation, release, coverage, CI, and public-license badges are retained only when backed by a live source.

## Impact

Documentation only. No source, dependency, workflow, settings, or deployment behavior changes.

## Validation

- changed path is exactly `README.md`
- README body is byte-for-byte unchanged
- `git diff --check`
- badge and workflow targets verified against current repository state
