### PR TITLE
chore(deps): add disabled Renovate bootstrap

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabled": false
+}


### PR DESCRIPTION
Adds only the canonical disabled Renovate configuration. It cannot create dependency branches or pull requests. This is the reversible first step before selected-repository App access and hosted zero-mutation proof.\n\nVerification:\n- byte-equal to the canonical fleet-maintenance bootstrap artifact\n- JSON parse passed\n- Renovate 44.29.4 config validation passed (optional RE2 fallback warning only)\n- git diff --check