### PR TITLE
chore(deps): activate Renovate ownership

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,70 +1,38 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "America/New_York"
-    open-pull-requests-limit: 10
+      interval: 'weekly'
+      day: 'monday'
+      time: '07:00'
+      timezone: 'America/Los_Angeles'
+    open-pull-requests-limit: 0
     commit-message:
-      # Type must be a single word (no hyphens) for the conventional-commits
-      # parser used by PR Lint. `include: scope` adds `(deps)` / `(deps-dev)`
-      # automatically — hyphen in the scope is fine.
-      prefix: "chore"
-      include: "scope"
+      prefix: 'chore'
+      include: 'scope'
     labels:
-      - "dependencies"
-      - "npm"
+      - 'dependencies'
+      - 'npm'
     assignees:
-      - "pdugan20"
+      - 'pdugan20'
     reviewers:
-      - "pdugan20"
-    # Skip major-version bumps — they regularly break CI and need a human.
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    groups:
-      jest:
-        patterns:
-          - "jest"
-          - "jest-*"
-          - "@jest/*"
-          - "@types/jest"
-          - "ts-jest"
-      dev-dependencies:
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
-      production-dependencies:
-        dependency-type: "production"
-        update-types:
-          - "minor"
-          - "patch"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      - 'pdugan20'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "America/Los_Angeles"
-    cooldown:
-      default-days: 14
-    open-pull-requests-limit: 5
+      interval: 'weekly'
+      day: 'monday'
+      time: '07:10'
+      timezone: 'America/Los_Angeles'
+    open-pull-requests-limit: 0
     commit-message:
-      prefix: "ci"
+      prefix: 'ci'
     labels:
-      - "dependencies"
-      - "github-actions"
+      - 'dependencies'
+      - 'github-actions'
     assignees:
-      - "pdugan20"
+      - 'pdugan20'
     reviewers:
-      - "pdugan20"
-    groups:
-      github-actions:
-        patterns: ["*"]
-        update-types:
-          - "minor"
-          - "patch"
+      - 'pdugan20'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Validate Chrome extension
         run: npm run extension:validate
 
+      - name: Verify dependency automation policy
+        run: node --test scripts/automation-policy.test.cjs
+
       - name: Archive production artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,79 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabled": false
+  "enabled": true,
+  "extends": ["config:recommended"],
+  "enabledManagers": ["npm", "github-actions"],
+  "semanticCommits": "enabled",
+  "timezone": "America/Los_Angeles",
+  "dependencyDashboard": true,
+  "dependencyDashboardAutoclose": true,
+  "labels": ["dependencies"],
+  "branchConcurrentLimit": 3,
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 2,
+  "rebaseWhen": "behind-base-branch",
+  "platformAutomerge": true,
+  "automergeType": "pr",
+  "automergeStrategy": "squash",
+  "internalChecksFilter": "strict",
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"],
+    "minimumReleaseAge": "7 days",
+    "automerge": true
+  },
+  "packageRules": [
+    {
+      "description": "Stable npm runtime non-major updates",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies", "optionalDependencies"],
+      "matchCurrentVersion": "!/^0\\./",
+      "matchUpdateTypes": ["patch", "minor", "digest", "pin", "pinDigest"],
+      "groupName": "runtime dependencies",
+      "minimumReleaseAge": "7 days",
+      "automerge": true
+    },
+    {
+      "description": "Stable npm development non-major updates",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchCurrentVersion": "!/^0\\./",
+      "matchUpdateTypes": ["patch", "minor", "digest", "pin", "pinDigest"],
+      "groupName": "development dependencies",
+      "minimumReleaseAge": "7 days",
+      "automerge": true
+    },
+    {
+      "description": "Stable npm override patch updates",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["overrides"],
+      "matchUpdateTypes": ["patch", "digest", "pin", "pinDigest"],
+      "minimumReleaseAge": "7 days",
+      "automerge": true
+    },
+    {
+      "description": "GitHub Actions non-major updates",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["patch", "minor", "digest", "pin", "pinDigest"],
+      "groupName": "github actions",
+      "minimumReleaseAge": "14 days",
+      "automerge": true
+    },
+    {
+      "description": "Pre-1.0 minor updates require exception handling",
+      "matchCurrentVersion": "/^0\\./",
+      "matchUpdateTypes": ["minor", "major"],
+      "dependencyDashboardApproval": true,
+      "automerge": false
+    },
+    {
+      "description": "All major updates require exception handling",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true,
+      "automerge": false
+    }
+  ]
 }

--- a/scripts/automation-policy.test.cjs
+++ b/scripts/automation-policy.test.cjs
@@ -1,0 +1,64 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const root = path.resolve(__dirname, '..');
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+test('Renovate owns only routine npm and Actions updates', () => {
+  const config = JSON.parse(read('renovate.json'));
+  const automergeRules = config.packageRules.filter((rule) => rule.automerge === true);
+  const majorRules = config.packageRules.filter((rule) =>
+    rule.matchUpdateTypes?.includes('major')
+  );
+  const preOneRules = config.packageRules.filter(
+    (rule) => rule.matchCurrentVersion === '/^0\\./'
+  );
+
+  assert.equal(config.enabled, true);
+  assert.deepEqual(new Set(config.enabledManagers), new Set(['npm', 'github-actions']));
+  assert.equal(config.vulnerabilityAlerts.enabled, false);
+  assert.equal(config.semanticCommits, 'enabled');
+  assert.equal(config.platformAutomerge, true);
+  assert.equal(config.automergeType, 'pr');
+  assert.equal(config.automergeStrategy, 'squash');
+  assert.equal(config.rebaseWhen, 'behind-base-branch');
+  assert.equal(config.internalChecksFilter, 'strict');
+  assert.equal(config.lockFileMaintenance.minimumReleaseAge, '7 days');
+  assert.ok(automergeRules.length > 0);
+  assert.ok(automergeRules.every((rule) => rule.minimumReleaseAge));
+  assert.ok(majorRules.length > 0);
+  assert.ok(majorRules.every((rule) => rule.automerge === false));
+  assert.ok(majorRules.every((rule) => rule.dependencyDashboardApproval === true));
+  assert.equal(preOneRules.length, 1);
+  assert.equal(preOneRules[0].automerge, false);
+  assert.equal(preOneRules[0].dependencyDashboardApproval, true);
+});
+
+test('Dependabot retains security coverage without routine version PRs', () => {
+  const dependabot = read('.github/dependabot.yml');
+
+  assert.deepEqual(
+    [...dependabot.matchAll(/package-ecosystem: '([^']+)'/g)].map((match) => match[1]),
+    ['npm', 'github-actions']
+  );
+  assert.deepEqual(
+    [...dependabot.matchAll(/directory: '([^']+)'/g)].map((match) => match[1]),
+    ['/', '/']
+  );
+  assert.equal((dependabot.match(/open-pull-requests-limit: 0/g) ?? []).length, 2);
+});
+
+test('CI enforces the ownership contract and releases remain tag-only', () => {
+  const ci = read('.github/workflows/ci.yml');
+  const release = read('.github/workflows/release.yml');
+
+  assert.match(ci, /node --test scripts\/automation-policy\.test\.cjs/);
+  assert.match(release, /push:\s*\n\s*tags:\s*\n\s*- 'v\*'/);
+  assert.doesNotMatch(ci, /pull-requests:\s*write/);
+  assert.doesNotMatch(ci, /contents:\s*write/);
+});


### PR DESCRIPTION
## Summary

- transfer routine npm and GitHub Actions version updates from Dependabot to Renovate
- preserve Dependabot security updates with compatible PR metadata
- auto-merge only aged, non-major updates after protected CI; hold majors and pre-1.0 breaking updates for dashboard approval
- enforce the dependency-automation contract in normal CI

## Safety

- Renovate App scope was added while `renovate.json` remained disabled; the automatic scope run completed without branch or PR mutation
- dependency vulnerability alerts and Dependabot security updates remain enabled
- lockfile maintenance and routine npm updates have a seven-day release-age quarantine; Actions use fourteen days
- releases remain tag-only and no package, lockfile, runtime, deployment, or ruleset change is included

## Verification

- `node --test scripts/automation-policy.test.cjs`
- Renovate 44.30.1 config validation
- `actionlint`
- `npm ci --ignore-scripts` and zero-audit result
- typecheck, lint, formatting, 189 tests, CLI/extension builds, and extension validation
- `git diff --check origin/main`
- independent Codex review found and prompted the lockfile release-age fix