### PR TITLE
fix(deps): automate aged pre-1.0 patches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,6 +63,14 @@
       "automerge": true
     },
     {
+      "description": "Pre-1.0 patch updates",
+      "matchManagers": ["npm"],
+      "matchCurrentVersion": "/^0\\./",
+      "matchUpdateTypes": ["patch", "digest", "pin", "pinDigest"],
+      "minimumReleaseAge": "7 days",
+      "automerge": true
+    },
+    {
       "description": "Pre-1.0 minor updates require exception handling",
       "matchCurrentVersion": "/^0\\./",
       "matchUpdateTypes": ["minor", "major"],

--- a/scripts/automation-policy.test.cjs
+++ b/scripts/automation-policy.test.cjs
@@ -15,8 +15,13 @@ test('Renovate owns only routine npm and Actions updates', () => {
   const majorRules = config.packageRules.filter((rule) =>
     rule.matchUpdateTypes?.includes('major')
   );
-  const preOneRules = config.packageRules.filter(
-    (rule) => rule.matchCurrentVersion === '/^0\\./'
+  const preOnePatchRules = config.packageRules.filter(
+    (rule) =>
+      rule.matchCurrentVersion === '/^0\\./' && rule.matchUpdateTypes?.includes('patch')
+  );
+  const preOneExceptionRules = config.packageRules.filter(
+    (rule) =>
+      rule.matchCurrentVersion === '/^0\\./' && rule.matchUpdateTypes?.includes('minor')
   );
 
   assert.equal(config.enabled, true);
@@ -34,9 +39,12 @@ test('Renovate owns only routine npm and Actions updates', () => {
   assert.ok(majorRules.length > 0);
   assert.ok(majorRules.every((rule) => rule.automerge === false));
   assert.ok(majorRules.every((rule) => rule.dependencyDashboardApproval === true));
-  assert.equal(preOneRules.length, 1);
-  assert.equal(preOneRules[0].automerge, false);
-  assert.equal(preOneRules[0].dependencyDashboardApproval, true);
+  assert.equal(preOnePatchRules.length, 1);
+  assert.equal(preOnePatchRules[0].automerge, true);
+  assert.equal(preOnePatchRules[0].minimumReleaseAge, '7 days');
+  assert.equal(preOneExceptionRules.length, 1);
+  assert.equal(preOneExceptionRules[0].automerge, false);
+  assert.equal(preOneExceptionRules[0].dependencyDashboardApproval, true);
 });
 
 test('Dependabot retains security coverage without routine version PRs', () => {


### PR DESCRIPTION
## Summary

- auto-merge pre-1.0 patch/digest updates after the seven-day quarantine and protected CI
- continue to hold pre-1.0 minor/major updates for Dependency Dashboard approval
- add a policy regression assertion for the distinction

## Evidence

The first interactive Renovate run correctly held breaking pre-1.0 and major updates, but left safe patch PR #139 without auto-merge. This closes that policy gap without widening the breaking-change lane.

## Verification

- policy tests: 3/3
- Renovate 44.29.5 config validation
- actionlint
- npm audit: 0 vulnerabilities
- typecheck, lint, formatting, 189 tests
- CLI and extension builds
- extension validation: 4/4
- diff check