### PR TITLE
fix(deps): require approval for lockfile maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,8 +22,8 @@
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 6am on monday"],
-    "minimumReleaseAge": "7 days",
-    "automerge": true
+    "dependencyDashboardApproval": true,
+    "automerge": false
   },
   "packageRules": [
     {

--- a/scripts/automation-policy.test.cjs
+++ b/scripts/automation-policy.test.cjs
@@ -33,7 +33,9 @@ test('Renovate owns only routine npm and Actions updates', () => {
   assert.equal(config.automergeStrategy, 'squash');
   assert.equal(config.rebaseWhen, 'behind-base-branch');
   assert.equal(config.internalChecksFilter, 'strict');
-  assert.equal(config.lockFileMaintenance.minimumReleaseAge, '7 days');
+  assert.equal(config.lockFileMaintenance.minimumReleaseAge, undefined);
+  assert.equal(config.lockFileMaintenance.dependencyDashboardApproval, true);
+  assert.equal(config.lockFileMaintenance.automerge, false);
   assert.ok(automergeRules.length > 0);
   assert.ok(automergeRules.every((rule) => rule.minimumReleaseAge));
   assert.ok(majorRules.length > 0);


### PR DESCRIPTION
## Summary

- remove the ineffective release-age status from synthetic lockfile maintenance
- require Dependency Dashboard approval and disable automerge for weekly lockfile refreshes
- keep ordinary aged stable and pre-1.0 patch updates self-draining

## Why

Final Codex review of the fleet receipt found that Renovate lockfile-maintenance updates do not carry a release timestamp. With `minimumReleaseAge` and the default timestamp-required behavior, their stability check can remain pending indefinitely. This keeps the unsupported class fail-closed and manual instead of consuming queue capacity.

## Verification

- `node --test scripts/automation-policy.test.cjs`
- `renovate-config-validator renovate.json` (Renovate 42.99.0; config valid)
- `git diff --check`

No ruleset, App scope, Mend setting, release, or deployment change.