### PR TITLE
fix(ci): authenticate Codecov uploads with OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   test:
     name: Test and Build
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
 
     steps:
@@ -51,6 +54,8 @@ jobs:
           files: ./coverage/lcov.info
           flags: unittests
           name: codecov-umbrella
+          use_oidc: true
+          fail_ci_if_error: true
 
       - name: Lint Claude Code config
         run: npm run lint:claude

--- a/scripts/automation-policy.test.cjs
+++ b/scripts/automation-policy.test.cjs
@@ -76,6 +76,45 @@ function assertTagOnlyReleaseWorkflow(release) {
   });
 }
 
+function extractNamedStep(workflow, name) {
+  const lines = workflow.split(/\r?\n/);
+  const marker = `      - name: ${name}`;
+  const starts = lines
+    .map((line, index) => (line === marker ? index : -1))
+    .filter((index) => index !== -1);
+
+  assert.equal(starts.length, 1, `${name} must appear exactly once`);
+
+  const start = starts[0];
+  const nextStep = lines.findIndex(
+    (line, index) => index > start && line.startsWith('      - name: ')
+  );
+  const end = nextStep === -1 ? lines.length : nextStep;
+
+  return lines.slice(start, end).join('\n');
+}
+
+function assertCodecovOIDCContract(ci) {
+  assert.match(ci, /^permissions:\n  contents: read\n\njobs:/m);
+  assert.match(
+    ci,
+    /jobs:\n  test:\n    name: Test and Build\n    permissions:\n      contents: read\n      id-token: write\n/m
+  );
+  assert.equal((ci.match(/^\s+id-token:/gm) ?? []).length, 1);
+
+  const codecovStep = extractNamedStep(ci, 'Upload coverage to Codecov');
+  assert.match(
+    codecovStep,
+    /^\s+uses: codecov\/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f\s+# v7\.0\.0$/m
+  );
+  assert.equal((codecovStep.match(/^\s+use_oidc:/gm) ?? []).length, 1);
+  assert.match(codecovStep, /^\s+use_oidc: true$/m);
+  assert.equal((codecovStep.match(/^\s+fail_ci_if_error:/gm) ?? []).length, 1);
+  assert.match(codecovStep, /^\s+fail_ci_if_error: true$/m);
+  assert.doesNotMatch(codecovStep, /^\s+(?:codecov_)?token:/m);
+  assert.doesNotMatch(codecovStep, /\$\{\{\s*secrets\./);
+}
+
 const expectedNativeSelectors = {
   'node_modules/@rolldown/binding-linux-arm64-gnu': {
     optional: true,
@@ -495,6 +534,24 @@ test('CI enforces the ownership contract and releases remain tag-only', () => {
   assert.ok(release.indexOf('name: Pin npm') < release.indexOf('run: npm ci'));
   assert.doesNotMatch(ci, /pull-requests:\s*write/);
   assert.doesNotMatch(ci, /contents:\s*write/);
+});
+
+test('Codecov uses job-scoped OIDC and fails closed without stored tokens', () => {
+  const ci = read('.github/workflows/ci.yml');
+
+  assertCodecovOIDCContract(ci);
+
+  const mutations = [
+    ci.replace('      id-token: write\n', ''),
+    ci.replace('          use_oidc: true\n', '          use_oidc: false\n'),
+    ci.replace('          fail_ci_if_error: true\n', '          fail_ci_if_error: false\n'),
+    ci.replace('          use_oidc: true\n', '          use_oidc: true\n          token: secret\n'),
+    ci.replace('permissions:\n  contents: read\n', 'permissions:\n  contents: read\n  id-token: write\n'),
+  ];
+
+  for (const mutated of mutations) {
+    assert.throws(() => assertCodecovOIDCContract(mutated), assert.AssertionError);
+  }
 });
 
 test('npm lockfile preserves every published native Linux selector tuple', () => {


### PR DESCRIPTION
Repairs fail-open Codecov telemetry: uploads on this protected branch fail with "Token required because branch is protected" while `fail_ci_if_error: false` masks the failure.

## Design (exact head dbea38ab)

- Job-scoped `permissions: contents: read, id-token: write` on the single test job (workflow-level stays `contents: read`)
- `use_oidc: true` + `fail_ci_if_error: true` on codecov-action, no stored token anywhere
- New policy suite asserting the OIDC/fail-closed contract against the real workflow file

## Verification

- Full pinned-toolchain matrix under Node 24.19.0 / npm 11.17.0: 17 suites / 189 tests, typecheck, lint, format, claudelint, build, extension validation, 8/8 automation-policy tests, actionlint — all green
- codecov-action pin fb8b3582… independently dereferenced to exactly tag v7.0.0
- `use_oidc`/`fail_ci_if_error` confirmed real inputs at the pinned SHA; fork-PR path confirmed to skip OIDC gracefully (no missing-id-token crash)

## Reviews

- Deep review (lane 1): CLEAN — job permissions strictly additive, no secrets, no new/unpinned actions
- Independent adversarial review (lane 2): terminal, **no blocking findings**. Four non-blocking test-hardening gaps recorded for follow-up (step-modifier bypasses such as `continue-on-error`, job-level env token scoping, unterminated permissions regex, second-upload-path coverage) plus a merge-and-watch note for the first post-main run.

Merge gate: exact-head CI on this PR must show a successful authenticated OIDC upload; after squash merge, the first push-to-main run is the terminal proof for the protected-branch case (single-line revert if Codecov rejects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8tGCXTQXGwxt3qDDaTWV3