### PR TITLE
chore(deps): update npm runtime contract to 11.19.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
       # Keep CI on the exact npm version that authors the committed lockfile.
       - name: Pin npm
-        run: npm install -g npm@11.17.0
+        run: npm install -g npm@11.19.0
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       # Keep tag builds on the same exact lockfile contract as pull requests and main.
       - name: Pin npm
-        run: npm install -g npm@11.17.0
+        run: npm install -g npm@11.19.0
 
       - name: Install dependencies
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
       },
       "engines": {
         "node": ">=24.19.0 <25",
-        "npm": ">=11.17.0 <12"
+        "npm": ">=11.19.0 <12"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
   "type": "module",
   "engines": {
     "node": ">=24.19.0 <25",
-    "npm": ">=11.17.0 <12"
+    "npm": ">=11.19.0 <12"
   },
-  "packageManager": "npm@11.17.0",
+  "packageManager": "npm@11.19.0",
   "lint-staged": {
     "src/**/*.{ts,tsx}": [
       "prettier --write",

--- a/scripts/automation-policy.test.cjs
+++ b/scripts/automation-policy.test.cjs
@@ -513,9 +513,9 @@ test('CI enforces the ownership contract and releases remain tag-only', () => {
   assert.equal(nodeVersion, '24.19.0');
   assert.deepEqual(packageJson.engines, {
     node: '>=24.19.0 <25',
-    npm: '>=11.17.0 <12',
+    npm: '>=11.19.0 <12',
   });
-  assert.equal(packageJson.packageManager, 'npm@11.17.0');
+  assert.equal(packageJson.packageManager, 'npm@11.19.0');
   assert.equal(packageJson.devDependencies['@types/node'], '^24.13.3');
   assert.deepEqual(packageLock.packages[''].engines, packageJson.engines);
   assert.equal(


### PR DESCRIPTION
## Summary
Complete replacement for the held Renovate PR #149. That PR updates `packageManager` alone, which the automation-policy suite rejects by design (cross-surface equality); this commit moves every pinned npm surface together:

- `package.json` `engines.npm` floor → `>=11.19.0 <12`
- `package.json` `packageManager` → `npm@11.19.0`
- `package-lock.json` root engines (regenerated under node 24.19.0 + exact npm 11.19.0; byte-reproducible)
- `.github/workflows/ci.yml` and `release.yml` `Pin npm` steps → 11.19.0
- `scripts/automation-policy.test.cjs` pinned expectations

npm 11.19.0 is the terminal 11.x release (published 2026-07-29, 17 days aged, not deprecated; engines admit node 24.19.0). npm 12 remains dashboard-gated as a major.

## Verification
- Full CI-mirror green under the pinned toolchain (fresh `npm ci`, typecheck, lint, format, tests, policy suite, build, extension validation, actionlint).
- Two independent adversarial reviews at exact head 1195d00001c5b1724e575f6c399c713a0b8ed248, both merge-permitting: lockfile byte-reproduction with negative controls, all five single-surface downgrade mutations fail closed, and the five-surface lockstep downgrade also fails (absolute literal anchors in the policy suite).
- `chore(deps)` cannot cut a release here: release-it is manual, `release.yml` is tag-push-only, changelog hides `chore`.

Renovate should autoclose #149 as superseded after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8tGCXTQXGwxt3qDDaTWV3